### PR TITLE
Enable SSL Certificate Verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ target/
 # IntelliJ IDEA IDE
 *.iml
 .idea/
+
+# Emacs editor saves
+*~
+\#*\#

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip install orionsdk
 
 ## Usage
 
-```
+```python
 import orionsdk
 
 swis = orionsdk.SwisClient("server", "username", "password")
@@ -20,6 +20,24 @@ aliases = swis.invoke('Metadata.Entity', 'GetAliases', 'SELECT B.Caption FROM Or
 print(aliases)
 ```
 
+## SSL Certificate Verification
+
+Initial support for SSL certificate valuation was added in 0.0.4. To
+enable this, you will need to save the self-signed cert to a file. One
+way of doing this is with OpenSSL:
+
+```bash
+openssl s_client -connect server:17778
+```
+
+Then add an entry to your hosts file for ``SolarWinds-Orion`` and you
+will be able to verify via doing the following:
+
+```python
+import orionsdk
+swis = orionsdk.SwisClient("SolarWinds-Orion", "username", "password", verify="server.pem")
+swis.query("SELECT NodeID from Orion.Nodes")
+```
 
 ## License
 

--- a/orionsdk/__init__.py
+++ b/orionsdk/__init__.py
@@ -15,4 +15,4 @@
 from .swisclient import SwisClient
 
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"

--- a/orionsdk/swisclient.py
+++ b/orionsdk/swisclient.py
@@ -11,10 +11,11 @@ def _json_serial(obj):
 
 
 class SwisClient:
-    def __init__(self, hostname, username, password):
+    def __init__(self, hostname, username, password, verify=False):
         self.url = "https://{}:17778/SolarWinds/InformationService/v3/Json/".\
                 format(hostname)
         self.credentials = (username, password)
+        self.verify = verify
 
     def query(self, query, **params):
         return self._req(
@@ -44,6 +45,6 @@ class SwisClient:
     def _req(self, method, frag, data=None):
         return requests.request(method, self.url + frag,
                                 data=json.dumps(data, default=_json_serial),
-                                verify=False,
+                                verify=self.verify,
                                 auth=self.credentials,
                                 headers={'Content-Type': 'application/json'})

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == 'publish':
 
 setup(
     name="orionsdk",
-    version="0.0.3",  # Update also in __init__ ;
+    version="0.0.4",  # Update also in __init__ ;
     description="Python API for the SolarWinds Orion SDK",
     long_description="Python client for interacting with the SolarWinds Orion API",
     author="SolarWinds",


### PR DESCRIPTION
A simple change to enable passing of verify down to requests so that there is the option of doing SSL Certificate Verification. Currently the options for this are quite limited due to the cert by default being self signed and having a `CN` of `SolarWinds-Orion`.

Also bumped the packaging version too...