### PR TITLE
solarwinds/orionsdk-python fix - updating setup.cfg to use underscore

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@
 universal=1
 
 [metadata]
-description-file = README.md
+description_file = README.md
 
 
 [pep8]


### PR DESCRIPTION
solarwinds/orionsdk-python fix - updating setup.cfg to use underscorein description_file per pypa/setuptools#4910